### PR TITLE
Add a balance field

### DIFF
--- a/src/fintrackr/schema.sql
+++ b/src/fintrackr/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE transactions(
     id SERIAL PRIMARY KEY,
     posted_date date NOT NULL,
     amount money NOT NULL,
+    balance money NOT NULL,
     description text, /* e.g merchant name on cc transaction */
     metadatum_id integer NOT NULL REFERENCES data_load_metadata(id)
 );


### PR DESCRIPTION
WDYT? For a transaction in/out of bank account, this is the bank account balance after that transaction. For a credit card, this is the balance carried on the card at the time of the transaction. It's in the original data, so making sure it gets into the db. Also necessary if one wants to plot bank account balance over time (at least in absolute dollar amounts; the alternative is to display only change over time).